### PR TITLE
Add explicit whale pun in guidelines

### DIFF
--- a/guidelines.md
+++ b/guidelines.md
@@ -9,7 +9,7 @@ This repository is dedicated to all things whale-related. Everyone is welcome to
 - This includes whale pictures, whale code, whale text, whale facts, etc
 - Be respectful and family-friendly with your content
 - Be reasonable with the size of your PR's, they should not contain huge files
-- Any content including whale puns will be accepted. This includes guideline modifications
+- Whale puns are welcome and encouraged as they are whale-related content, and all contributions containing whale puns will seriously be considered for addition to the repo
 
 ## How to Contribute
 - Submit a pull request with your contribution

--- a/guidelines.md
+++ b/guidelines.md
@@ -9,7 +9,7 @@ This repository is dedicated to all things whale-related. Everyone is welcome to
 - This includes whale pictures, whale code, whale text, whale facts, etc
 - Be respectful and family-friendly with your content
 - Be reasonable with the size of your PR's, they should not contain huge files
-- Contributions from HackerNews users will be a bit more lenient
+- Any content including whale puns will be accepted. This includes guideline modifications
 
 ## How to Contribute
 - Submit a pull request with your contribution

--- a/guidelines.md
+++ b/guidelines.md
@@ -9,6 +9,7 @@ This repository is dedicated to all things whale-related. Everyone is welcome to
 - This includes whale pictures, whale code, whale text, whale facts, etc
 - Be respectful and family-friendly with your content
 - Be reasonable with the size of your PR's, they should not contain huge files
+- Contributions from HackerNews users will be a bit more lenient
 
 ## How to Contribute
 - Submit a pull request with your contribution


### PR DESCRIPTION
I added a clause in the content requirement to make it clear that whale puns qualify is acceptable content. Clearly, it is within current guidelines. Additionally, we have received very little activity, so we need to make it easier for user to post. People don't have realized that whale puns is sufficient to qualify to submit and contribute.